### PR TITLE
Make compatible with PHP's pattern matching RFC

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
   "keywords": ["language", "module", "xp"],
   "require" : {
     "xp-framework/core": "^12.0 | ^11.0 | ^10.0",
-    "xp-framework/compiler": "^9.0 | ^8.0",
+    "xp-framework/compiler": "^9.0",
+    "xp-framework/ast": "^11.8",
     "php" : ">=7.4.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^12.0 | ^11.0 | ^10.0",
     "xp-framework/compiler": "^9.0",
-    "xp-framework/ast": "^11.8",
+    "xp-framework/ast": "^12.0 | ^11.8",
     "php" : ">=7.4.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/syntax/php/IsArrayStructure.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsArrayStructure.class.php
@@ -4,11 +4,17 @@ use lang\ast\Type;
 use util\Objects;
 
 class IsArrayStructure extends Type {
-  public $patterns;
-  public $rest= false;
+  public $patterns, $rest;
 
-  public function __construct($patterns= []) {
+  /**
+   * Creates a object structure "type"
+   *
+   * @param  lang.ast.Type[] $patterns
+   * @param  bool $rest
+   */
+  public function __construct($patterns= [], $rest= false) {
     $this->patterns= $patterns;
+    $this->rest= $rest;
   }
 
   /** @return string */

--- a/src/main/php/lang/ast/syntax/php/IsArrayStructure.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsArrayStructure.class.php
@@ -1,0 +1,18 @@
+<?php namespace lang\ast\syntax\php;
+
+use lang\ast\Type;
+use util\Objects;
+
+class IsArrayStructure extends Type {
+  public $patterns;
+  public $rest= false;
+
+  public function __construct($patterns= []) {
+    $this->patterns= $patterns;
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'('.($this->rest ? '>=' : '===').' '.Objects::stringOf($this->patterns).')';
+  }
+}

--- a/src/main/php/lang/ast/syntax/php/IsArrayStructure.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsArrayStructure.class.php
@@ -7,7 +7,7 @@ class IsArrayStructure extends Type {
   public $patterns, $rest;
 
   /**
-   * Creates a object structure "type"
+   * Creates a array structure "type"
    *
    * @param  lang.ast.Type[] $patterns
    * @param  bool $rest

--- a/src/main/php/lang/ast/syntax/php/IsBinding.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsBinding.class.php
@@ -1,0 +1,22 @@
+<?php namespace lang\ast\syntax\php;
+
+use lang\ast\Type;
+use util\Objects;
+
+class IsBinding extends Type {
+  public $variable;
+
+  /**
+   * Creates a binding "type"
+   *
+   * @param  lang.ast.nodes.Variable
+   */
+  public function __construct($variable) {
+    $this->variable= $variable;
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'('.Objects::stringOf($this->variable).')';
+  }
+}

--- a/src/main/php/lang/ast/syntax/php/IsBinding.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsBinding.class.php
@@ -1,7 +1,6 @@
 <?php namespace lang\ast\syntax\php;
 
 use lang\ast\Type;
-use util\Objects;
 
 class IsBinding extends Type {
   public $variable;
@@ -9,7 +8,7 @@ class IsBinding extends Type {
   /**
    * Creates a binding "type"
    *
-   * @param  lang.ast.nodes.Variable
+   * @param  lang.ast.nodes.Variable $variable
    */
   public function __construct($variable) {
     $this->variable= $variable;
@@ -17,6 +16,6 @@ class IsBinding extends Type {
 
   /** @return string */
   public function toString() {
-    return nameof($this).'('.Objects::stringOf($this->variable).')';
+    return nameof($this).'('.$this->variable->pointer.')';
   }
 }

--- a/src/main/php/lang/ast/syntax/php/IsBinding.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsBinding.class.php
@@ -17,7 +17,7 @@ class IsBinding extends Type {
 
   /** @return string */
   public function toString() {
-    $restriction= $this->restriction ? ' & '.Objects::stringOf($this->restriction) : '';
+    $restriction= $this->restriction ? ' & '.$this->restriction->toString() : '';
     return nameof($this).'('.$this->variable->pointer.$restriction.')';
   }
 }

--- a/src/main/php/lang/ast/syntax/php/IsBinding.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsBinding.class.php
@@ -4,6 +4,7 @@ use lang\ast\Type;
 
 class IsBinding extends Type {
   public $variable;
+  public $restriction= null;
 
   /**
    * Creates a binding "type"
@@ -16,6 +17,7 @@ class IsBinding extends Type {
 
   /** @return string */
   public function toString() {
-    return nameof($this).'('.$this->variable->pointer.')';
+    $restriction= $this->restriction ? ' & '.Objects::stringOf($this->restriction) : '';
+    return nameof($this).'('.$this->variable->pointer.$restriction.')';
   }
 }

--- a/src/main/php/lang/ast/syntax/php/IsComparable.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsComparable.class.php
@@ -1,0 +1,24 @@
+<?php namespace lang\ast\syntax\php;
+
+use lang\ast\Type;
+use util\Objects;
+
+class IsComparable extends Type {
+  public $value, $operator;
+
+  /**
+   * Creates a comparable "type"
+   *
+   * @param  lang.ast.Type[] $patterns
+   * @param  string $operator
+   */
+  public function __construct($value, $operator) {
+    $this->value= $value;
+    $this->operator= $operator;
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'('.$this->operator.' '.Objects::stringOf($this->value).')';
+  }
+}

--- a/src/main/php/lang/ast/syntax/php/IsComparison.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsComparison.class.php
@@ -3,13 +3,13 @@
 use lang\ast\Type;
 use util\Objects;
 
-class IsComparable extends Type {
+class IsComparison extends Type {
   public $value, $operator;
 
   /**
-   * Creates a comparable "type"
+   * Creates a comparison "type"
    *
-   * @param  lang.ast.Type[] $patterns
+   * @param  lang.ast.Node $value
    * @param  string $operator
    */
   public function __construct($value, $operator) {

--- a/src/main/php/lang/ast/syntax/php/IsCompound.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsCompound.class.php
@@ -1,0 +1,24 @@
+<?php namespace lang\ast\syntax\php;
+
+use lang\ast\Type;
+use util\Objects;
+
+class IsCompound extends Type {
+  public $patterns, $operator;
+
+  /**
+   * Creates a compound "type"
+   *
+   * @param  lang.ast.Type[] $patterns
+   * @param  string $operator
+   */
+  public function __construct($patterns, $operator) {
+    $this->patterns= $patterns;
+    $this->operator= $operator;
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'('.$this->operator.' '.Objects::stringOf($this->patterns).')';
+  }
+}

--- a/src/main/php/lang/ast/syntax/php/IsIdentical.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsIdentical.class.php
@@ -1,0 +1,22 @@
+<?php namespace lang\ast\syntax\php;
+
+use lang\ast\Type;
+use util\Objects;
+
+class IsIdentical extends Type {
+  public $value;
+
+  /**
+   * Creates a identical "type"
+   *
+   * @param  lang.ast.Node $value
+   */
+  public function __construct($value) {
+    $this->value= $value;
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'('.Objects::stringOf($this->value).')';
+  }
+}

--- a/src/main/php/lang/ast/syntax/php/IsObjectStructure.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsObjectStructure.class.php
@@ -1,0 +1,18 @@
+<?php namespace lang\ast\syntax\php;
+
+use lang\ast\Type;
+use util\Objects;
+
+class IsObjectStructure extends Type {
+  public $type, $patterns;
+
+  public function __construct($type, $patterns= []) {
+    $this->type= $type;
+    $this->patterns= $patterns;
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'('.Objects::stringOf($this->type).' '.Objects::stringOf($this->patterns).')';
+  }
+}

--- a/src/main/php/lang/ast/syntax/php/IsObjectStructure.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsObjectStructure.class.php
@@ -6,6 +6,12 @@ use util\Objects;
 class IsObjectStructure extends Type {
   public $type, $patterns;
 
+  /**
+   * Creates a object structure "type"
+   *
+   * @param  lang.ast.Type $type
+   * @param  lang.ast.Type[] $patterns
+   */
   public function __construct($type, $patterns= []) {
     $this->type= $type;
     $this->patterns= $patterns;

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -64,6 +64,13 @@ class IsOperator implements Extension {
         $parse->forward();
         $r= new IsBinding(new Variable($parse->token->value));
         $parse->forward();
+
+        // See https://wiki.php.net/rfc/pattern-matching#applying_patterns_to_bound_variables
+        if ('&' === $parse->token->value) {
+          $parse->forward();
+          $r->restriction= $pattern($parse, $types);
+        }
+        return $r;
       } else if ('>' === $parse->token->value || '>=' === $parse->token->value || '<' === $parse->token->value || '<=' === $parse->token->value) {
         $operator= $parse->token->value;
         $parse->forward();
@@ -108,9 +115,9 @@ class IsOperator implements Extension {
         } else {
           return new IsCompound([$r, $n], $operator);
         }
-      } else {
-        return $r;
       }
+
+      return $r;
     };
 
     $language->infix('is', 60, function($parse, $token, $left) use($pattern) {
@@ -182,11 +189,20 @@ class IsOperator implements Extension {
       } else if ($pattern instanceof IsIdentical) {
         return new BinaryExpression($expression, '===', $pattern->value);
       } else if ($pattern instanceof IsBinding) {
-        return new Braced(new BinaryExpression(
-          new Braced(new Assignment($pattern->variable, '=', $expression)),
-          '||',
-          new Literal('true')
-        ));
+        $bind= new Assignment($pattern->variable, '=', $expression);
+        $compound= new Braced(new BinaryExpression(new Braced($bind), '||', new Literal('true')));
+
+        // Assign to temporary variable, only actually bind if restriction matches
+        if ($pattern->restriction) {
+          $bind->expression= new Variable($codegen->symbol());
+          $compound= new BinaryExpression(
+            $match($codegen, new Braced(new Assignment($bind->expression, '=', $expression)), $pattern->restriction),
+            '&&',
+            $compound
+          );
+        }
+
+        return $compound;
       }
 
       // Ensure expressions are only evaluated once.

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -54,7 +54,7 @@ class IsOperator implements Extension {
           $parse->expecting(')', 'object structure');
         } else if ('::' === $parse->token->value) {
           $parse->forward();
-          $r= new IsComparison(new ScopeExpression($r->literal(), new Literal($parse->token->value)), '===');
+          $r= new IsIdentical(new ScopeExpression($r->literal(), new Literal($parse->token->value)));
           $parse->forward();
         }
       } else if ('string' === $parse->token->kind || 'integer' === $parse->token->kind || 'decimal' === $parse->token->kind) {
@@ -90,7 +90,7 @@ class IsOperator implements Extension {
         $parse->expecting(']', 'array structure');
       } else if ('^' === $parse->token->value) {
         $parse->forward();
-        $r= new IsComparison($types->expression($parse, 0), '===');
+        $r= new IsIdentical($types->expression($parse, 0));
       } else {
         $parse->expecting('a type or literal', 'is');
         return null;

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -224,10 +224,11 @@ class IsOperator implements Extension {
           )
         );
         foreach ($pattern->patterns as $key => $p) {
-          $compound= new BinaryExpression($compound, '&&', $match(
-            $codegen,
-            new Braced(new BinaryExpression(new OffsetExpression($temp, new Literal((string)$key)), '??', $null)),
-            $p
+          $offset= new Literal((string)$key);
+          $compound= new BinaryExpression($compound, '&&', new BinaryExpression(
+            new InvokeExpression(new Literal('array_key_exists'), [$offset, $temp]),
+            '&&',
+            $match($codegen, new OffsetExpression($temp, $offset), $p),
           ));
         }
         return $compound;

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -14,7 +14,6 @@ use lang\ast\nodes\{
   MatchExpression,
   OffsetExpression,
   ScopeExpression,
-  TernaryExpression,
   Variable
 };
 use lang\ast\syntax\Extension;
@@ -183,11 +182,10 @@ class IsOperator implements Extension {
       } else if ($pattern instanceof IsIdentical) {
         return new BinaryExpression($expression, '===', $pattern->value);
       } else if ($pattern instanceof IsBinding) {
-        $true= new Literal('true');
-        return new Braced(new TernaryExpression(
+        return new Braced(new BinaryExpression(
           new Braced(new Assignment($pattern->variable, '=', $expression)),
-          $true,
-          $true
+          '||',
+          new Literal('true')
         ));
       }
 

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -23,7 +23,11 @@ class IsOperator implements Extension {
 
   public function setup($language, $emitter) {
     $pattern= function($parse, $types) use(&$pattern) {
-      if ('(' === $parse->token->value || '?' === $parse->token->value) {
+      if ('(' === $parse->token->value) {
+        $parse->forward();
+        $r= $pattern($parse, $types);
+        $parse->expecting(')', 'dnf');
+      } else if ('?' === $parse->token->value) {
         $r= $types->type0($parse, false);
       } else if ('name' === $parse->token->kind) {
         $r= $types->type0($parse, false);
@@ -94,7 +98,15 @@ class IsOperator implements Extension {
       $operator= $parse->token->value;
       if ('|' === $operator || '&' === $operator) {
         $parse->forward();
-        return new IsCompound([$r, $pattern($parse, $types)], $operator);
+        $n= $pattern($parse, $types);
+
+        // Merge compound types with the same operators, keeping evaluation order
+        if ($n instanceof IsCompound && $operator === $n->operator) {
+          array_unshift($n->patterns, $r);
+          return $n;
+        } else {
+          return new IsCompound([$r, $n], $operator);
+        }
       } else {
         return $r;
       }

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -1,64 +1,184 @@
 <?php namespace lang\ast\syntax\php;
 
 use lang\ast\Node;
-use lang\ast\nodes\{Assignment, BinaryExpression, Braced, InstanceOfExpression, InvokeExpression, Literal, Variable};
+use lang\ast\nodes\{
+  Assignment,
+  ArrayLiteral,
+  BinaryExpression,
+  Braced,
+  InstanceOfExpression,
+  InvokeExpression,
+  Literal,
+  OffsetExpression,
+  InstanceExpression,
+  ScopeExpression,
+  Variable
+};
 use lang\ast\syntax\Extension;
-use lang\ast\types\{IsArray, IsFunction, IsMap, IsUnion, IsIntersection};
+use lang\ast\types\{IsArray, IsLiteral, IsFunction, IsMap, IsUnion, IsIntersection, IsNullable, IsValue};
 
 class IsOperator implements Extension {
 
   public function setup($language, $emitter) {
-    $language->infix('is', 60, function($parse, $token, $left) {
-      $t= $this->type($parse, true);
+    $pattern= function($parse, $types) use(&$pattern) {
+      if ('(' === $parse->token->value || '?' === $parse->token->value) {
+        $r= $types->type0($parse, false);
+      } else if ('name' === $parse->token->kind) {
+        $r= $types->type0($parse, false);
 
-      $node= new InstanceOfExpression($left, $t ?: $this->expression($parse, 0));
-      $node->kind= 'is';
-      return $node;
-    });
+        if ('(' === $parse->token->value) {
+          $r= new IsObjectStructure($r);
+          $parse->forward();
+          if (')' !== $parse->token->value) do {
+            if (':' === $parse->token->value) {
+              $parse->forward();
+              $variable= $parse->token;
+              $parse->expecting('(variable)', 'object structure');
+              $member= $parse->token->value;
+              array_unshift($parse->queue, $parse->token);
+              $parse->token= $variable;
+            } else {
+              $member= $parse->token->value;
+              $parse->forward();
+              $parse->expecting(':', 'object structure');
+            }
+            $r->patterns[$member]= $pattern($parse, $types);
+          } while (',' === $parse->token->value && $parse->forward() | true);
+          $parse->expecting(')', 'object structure');
+        } else if ('::' === $parse->token->value) {
+          $parse->forward();
+          $r= new IsComparable(new ScopeExpression($r->literal(), new Literal($parse->token->value)), '===');
+          $parse->forward();
+        }
+      } else if ('string' === $parse->token->kind || 'integer' === $parse->token->kind || 'decimal' === $parse->token->kind) {
+        $r= new IsComparable(new Literal($parse->token->value), '===');
+        $parse->forward();
+      } else if ('variable' === $parse->token->kind) {
+        $parse->forward();
+        $r= new IsBinding(new Variable($parse->token->value));
+        $parse->forward();
+      } else if ('>' === $parse->token->value || '>=' === $parse->token->value || '<' === $parse->token->value || '<=' === $parse->token->value) {
+        $operator= $parse->token->value;
+        $parse->forward();
+        $r= new IsComparable(new Literal($parse->token->value), $operator);
+        $parse->forward();
+      } else if ('[' === $parse->token->value) {
+        $r= new IsArrayStructure();
+        $parse->forward();
+        if (']' !== $parse->token->value) do {
+          if ('...' === $parse->token->value) {
+            $r->rest= true;
+            $parse->forward();
+            break;
+          }
 
-    $test= function($literal, $expr, $temp) {
-      static $is= [
-        'string'   => true,
-        'int'      => true,
-        'float'    => true,
-        'bool'     => true,
-        'array'    => true,
-        'object'   => true,
-        'callable' => true,
-        'iterable' => true,
-      ];
-
-      if (isset($is[$literal])) {
-        return new InvokeExpression(new Literal('is_'.$literal), [$expr]);
-      } else if ('mixed' === $literal) {
-        return new Literal('true');
+          $p= $pattern($parse, $types);
+          if ('=>' === $parse->token->value) {
+            $parse->forward();
+            $r->patterns[$p->value->expression]= $pattern($parse, $types);
+          } else {
+            $r->patterns[]= $p;
+          }
+        } while (',' === $parse->token->value && $parse->forward() | true);
+        $parse->expecting(']', 'array structure');
+      } else if ('^' === $parse->token->value) {
+        $parse->forward();
+        $r= new IsComparable($types->expression($parse, 0), '===');
       } else {
-        return new InstanceOfExpression($expr, $literal);
+        $parse->expecting('a type or literal', 'is');
+        return null;
+      }
+
+      $operator= $parse->token->value;
+      if ('|' === $operator || '&' === $operator) {
+        $parse->forward();
+        return new IsCompound([$r, $pattern($parse, $types)], $operator);
+      } else {
+        return $r;
       }
     };
 
-    $emitter->transform('is', function($codegen, $node) use($test) {
-      $t= $node->type;
-      if ($t instanceof Node) {
-        return new InvokeExpression(new Literal('is'), [$node->type, $node->expression]);
-      }
+    $language->infix('is', 60, function($parse, $token, $left) use($pattern) {
+      return new PatternMatch($left, $pattern($parse, $this), $left->line);
+    });
 
-      // Verify builtin primitives with is_XXX(), value types with instanceof, others using is()
-      if ($t instanceof IsFunction || $t instanceof IsArray || $t instanceof IsMap || $t instanceof IsUnion || $t instanceof IsIntersection) {
-        return new InvokeExpression(new Literal('is'), [new Literal('"'.$t->name().'"'), $node->expression]);
-      } else {
-        $literal= $t->literal();
-        $temp= new Variable($codegen->symbol());
-        if ('?' === $literal[0]) {
-          return new BinaryExpression(
-            new BinaryExpression(new Literal('null'), '===', new Braced(new Assignment($temp, '=', $node->expression))),
-            '||',
-            $test(substr($literal, 1), $temp, null)
-          );
+    $match= function($codegen, $expression, $pattern) use(&$match) {
+      // \util\cmd\Console::writeLine('[...] is ', $pattern);
+
+      if ($pattern instanceof IsLiteral) {
+        $literal= $pattern->literal();
+        if ('mixed' === $literal) {
+          return new Literal('true');
+        } else if ('true' === $literal || 'false' === $literal || 'null' === $literal) {
+          return new BinaryExpression(new Literal($literal), '===', $expression);
         } else {
-          return $test($literal, $node->expression, $temp);
+          return new InvokeExpression(new Literal('is_'.$literal), [$expression]);
         }
+      } else if ($pattern instanceof IsValue) {
+        return new InstanceOfExpression($expression, $pattern);
+      } else if ($pattern instanceof IsComparable) {
+        return new BinaryExpression($expression, $pattern->operator, $pattern->value);
+      } else if ($pattern instanceof IsNullable) {
+        $temp= new Variable($codegen->symbol());
+        return new BinaryExpression(
+          new BinaryExpression(new Literal('null'), '===', new Braced(new Assignment($temp, '=', $expression))),
+          '||',
+          $match($codegen, $temp, $pattern->element)
+        );
+      } else if ($pattern instanceof IsBinding) {
+        return new BinaryExpression(
+          new Literal('true'),
+          '|',
+          new Braced(new Assignment($pattern->variable, '=', $expression))
+        );
+      } else if ($pattern instanceof IsCompound) {
+        $s= sizeof($pattern->patterns);
+        if (1 === $s) return $match($codegen, $expression, $pattern->patterns[0]);
+
+        $temp= new Variable($codegen->symbol());
+        $compound= $match($codegen, new Braced(new Assignment($temp, '=', $expression)), $pattern->patterns[0]);
+        for ($i= 1, $op= $pattern->operator.$pattern->operator; $i < $s; $i++) {
+          $compound= new BinaryExpression($compound, $op, $match($codegen, $temp, $pattern->patterns[$i]));
+        }
+        return new Braced($compound);
+      } else if ($pattern instanceof IsArrayStructure) {
+        $null= new Literal('null');
+        $temp= new Variable($codegen->symbol());
+        $compound= new BinaryExpression(
+          new InvokeExpression(new Literal('is_array'), [new Assignment($temp, '=', $expression)]),
+          '&&',
+          new BinaryExpression(
+            new InvokeExpression(new Literal('sizeof'), [$temp]),
+            $pattern->rest ? '>=' : '===',
+            new Literal(sizeof($pattern->patterns))
+          )
+        );
+        foreach ($pattern->patterns as $key => $p) {
+          $compound= new BinaryExpression($compound, '&&', $match(
+            $codegen,
+            new Braced(new BinaryExpression(new OffsetExpression($temp, new Literal($key)), '??', $null)),
+            $p
+          ));
+        }
+        return $compound;
+      } else if ($pattern instanceof IsObjectStructure) {
+        $temp= new Variable($codegen->symbol());
+        $compound= new InstanceOfExpression(new Braced(new Assignment($temp, '=', $expression)), $pattern->type);
+        foreach ($pattern->patterns as $key => $p) {
+          $compound= new BinaryExpression($compound, '&&', $match(
+            $codegen,
+            new InstanceExpression($temp, new Literal($key)),
+            $p
+          ));
+        }
+        return $compound;
+      } else {
+        return new InvokeExpression(new Literal('is'), [new Literal('"'.$pattern->name().'"'), $expression]);
       }
+    };
+
+    $emitter->transform('is', function($codegen, $node) use($match) {
+      return $match($codegen, $node->expression, $node->pattern);
     });
   }
 }

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -1,21 +1,23 @@
 <?php namespace lang\ast\syntax\php;
 
-use lang\ast\Node;
 use lang\ast\nodes\{
-  Assignment,
   ArrayLiteral,
+  Assignment,
   BinaryExpression,
   Braced,
+  InstanceExpression,
   InstanceOfExpression,
   InvokeExpression,
   Literal,
+  MatchCondition,
+  MatchExpression,
   OffsetExpression,
-  InstanceExpression,
   ScopeExpression,
   Variable
 };
 use lang\ast\syntax\Extension;
 use lang\ast\types\{IsArray, IsLiteral, IsFunction, IsMap, IsUnion, IsIntersection, IsNullable, IsValue};
+use lang\ast\{Node, Token};
 
 class IsOperator implements Extension {
 
@@ -100,6 +102,52 @@ class IsOperator implements Extension {
 
     $language->infix('is', 60, function($parse, $token, $left) use($pattern) {
       return new PatternMatch($left, $pattern($parse, $this), $left->line);
+    });
+
+    $language->prefix('match', 0, function($parse, $token) use($pattern) {
+      $patterns= false;
+      $condition= null;
+
+      if ('(' === $parse->token->value) {
+        $parse->forward();
+        $condition= $this->expression($parse, 0);
+        $parse->expecting(')', 'match');
+
+        // See https://wiki.php.net/rfc/pattern-matching#match_is_placement
+        if ('is' === $parse->token->value) {
+          $parse->forward();
+          $patterns= true;
+        }
+      }
+
+      $default= null;
+      $cases= [];
+      $parse->expecting('{', 'match');
+      while ('}' !== $parse->token->value) {
+        if ('default' === $parse->token->value) {
+          $parse->forward();
+          $parse->expecting('=>', 'match');
+          $default= $this->expression($parse, 0);
+        } else if ($patterns) {
+          $match= [new PatternMatch($condition, $pattern($parse, $this), $parse->token->line)];
+          $parse->expecting('=>', 'match');
+          $cases[]= new MatchCondition($match, $this->expression($parse, 0), $parse->token->line);
+        } else {
+          $match= [];
+          do {
+            $match[]= $this->expression($parse, 0);
+          } while (',' === $parse->token->value && $parse->forward() | true);
+          $parse->expecting('=>', 'match');
+          $cases[]= new MatchCondition($match, $this->expression($parse, 0), $parse->token->line);
+        }
+
+        if (',' === $parse->token->value) {
+          $parse->forward();
+        }
+      }
+      $parse->expecting('}', 'match');
+
+      return new MatchExpression($patterns ? null : $condition, $cases, $default, $token->line);
     });
 
     $match= function($codegen, $expression, $pattern) use(&$match) {

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -1,5 +1,6 @@
 <?php namespace lang\ast\syntax\php;
 
+use lang\IllegalStateException;
 use lang\ast\nodes\{
   ArrayLiteral,
   Assignment,
@@ -164,6 +165,8 @@ class IsOperator implements Extension {
     });
 
     $match= function($codegen, $expression, $pattern) use(&$match) {
+
+      // Basic type matching, literal comparison and variable binding
       if ($pattern instanceof IsLiteral) {
         $literal= $pattern->literal();
         if ('mixed' === $literal) {
@@ -175,34 +178,10 @@ class IsOperator implements Extension {
         }
       } else if ($pattern instanceof IsValue) {
         return new InstanceOfExpression($expression, $pattern);
+      } else if ($pattern instanceof IsArray || $pattern instanceof IsMap || $pattern instanceof IsFunction) {
+        return new InvokeExpression(new Literal('is'), [new Literal('"'.$pattern->name().'"'), $expression]);
       } else if ($pattern instanceof IsIdentical) {
         return new BinaryExpression($expression, '===', $pattern->value);
-      } else if ($pattern instanceof IsComparison) {
-        if ($expression instanceof Variable) {
-          $use= $init= $expression;
-        } else {
-          $use= new Variable($codegen->symbol());
-          $init= new Braced(new Assignment($use, '=', $expression));
-        }
-
-        return new BinaryExpression(
-          new InvokeExpression(new Literal('is_numeric'), [$init]),
-          '&&',
-          new BinaryExpression($use, $pattern->operator, $pattern->value)
-        );
-      } else if ($pattern instanceof IsNullable) {
-        if ($expression instanceof Variable) {
-          $use= $init= $expression;
-        } else {
-          $use= new Variable($codegen->symbol());
-          $init= new Braced(new Assignment($use, '=', $expression));
-        }
-
-        return new BinaryExpression(
-          new BinaryExpression(new Literal('null'), '===', $init),
-          '||',
-          $match($codegen, $use, $pattern->element)
-        );
       } else if ($pattern instanceof IsBinding) {
         $true= new Literal('true');
         return new Braced(new TernaryExpression(
@@ -210,28 +189,45 @@ class IsOperator implements Extension {
           $true,
           $true
         ));
-      } else if ($pattern instanceof IsCompound) {
-        $s= sizeof($pattern->patterns);
-        if (1 === $s) return $match($codegen, $expression, $pattern->patterns[0]);
+      }
 
-        if ($expression instanceof Variable) {
-          $use= $init= $expression;
-        } else {
-          $use= new Variable($codegen->symbol());
-          $init= new Braced(new Assignment($use, '=', $expression));
-        }
+      // Ensure expressions are only evaluated once.
+      if ($expression instanceof Variable) {
+        $use= $init= $expression;
+      } else {
+        $use= new Variable($codegen->symbol());
+        $init= new Braced(new Assignment($use, '=', $expression));
+      }
+
+      if ($pattern instanceof IsComparison) {
+        return new BinaryExpression(
+          new InvokeExpression(new Literal('is_numeric'), [$init]),
+          '&&',
+          new BinaryExpression($use, $pattern->operator, $pattern->value)
+        );
+      } else if ($pattern instanceof IsNullable) {
+        return new BinaryExpression(
+          new BinaryExpression(new Literal('null'), '===', $init),
+          '||',
+          $match($codegen, $use, $pattern->element)
+        );
+      } else if ($pattern instanceof IsCompound) {
         $compound= $match($codegen, $init, $pattern->patterns[0]);
-        for ($i= 1, $op= $pattern->operator.$pattern->operator; $i < $s; $i++) {
+        for ($i= 1, $s= sizeof($pattern->patterns), $op= $pattern->operator.$pattern->operator; $i < $s; $i++) {
           $compound= new BinaryExpression($compound, $op, $match($codegen, $use, $pattern->patterns[$i]));
         }
         return new Braced($compound);
-      } else if ($pattern instanceof IsArrayStructure) {
-        if ($expression instanceof Variable) {
-          $use= $init= $expression;
-        } else {
-          $use= new Variable($codegen->symbol());
-          $init= new Assignment($use, '=', $expression);
+      } else if ($pattern instanceof IsObjectStructure) {
+        $compound= new InstanceOfExpression($init, $pattern->type);
+        foreach ($pattern->patterns as $key => $p) {
+          $compound= new BinaryExpression($compound, '&&', $match(
+            $codegen,
+            new InstanceExpression($use, new Literal($key)),
+            $p
+          ));
         }
+        return $compound;
+      } else if ($pattern instanceof IsArrayStructure) {
         $compound= new BinaryExpression(
           new InvokeExpression(new Literal('is_array'), [$init]),
           '&&',
@@ -250,25 +246,10 @@ class IsOperator implements Extension {
           ));
         }
         return $compound;
-      } else if ($pattern instanceof IsObjectStructure) {
-        if ($expression instanceof Variable) {
-          $use= $init= $expression;
-        } else {
-          $use= new Variable($codegen->symbol());
-          $init= new Braced(new Assignment($use, '=', $expression));
-        }
-        $compound= new InstanceOfExpression($init, $pattern->type);
-        foreach ($pattern->patterns as $key => $p) {
-          $compound= new BinaryExpression($compound, '&&', $match(
-            $codegen,
-            new InstanceExpression($use, new Literal($key)),
-            $p
-          ));
-        }
-        return $compound;
-      } else {
-        return new InvokeExpression(new Literal('is'), [new Literal('"'.$pattern->name().'"'), $expression]);
       }
+
+      // Should be unreachable
+      throw new IllegalStateException('Unsupported pattern '.$pattern->toString());
     };
 
     $emitter->transform('is', function($codegen, $node) use($match) {

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -57,7 +57,7 @@ class IsOperator implements Extension {
           $parse->forward();
         }
       } else if ('string' === $parse->token->kind || 'integer' === $parse->token->kind || 'decimal' === $parse->token->kind) {
-        $r= new IsComparison(new Literal($parse->token->value), '===');
+        $r= new IsIdentical(new Literal($parse->token->value));
         $parse->forward();
       } else if ('variable' === $parse->token->kind) {
         $parse->forward();
@@ -176,8 +176,18 @@ class IsOperator implements Extension {
         }
       } else if ($pattern instanceof IsValue) {
         return new InstanceOfExpression($expression, $pattern);
+      } else if ($pattern instanceof IsIdentical) {
+        return new BinaryExpression($expression, '===', $pattern->value);
       } else if ($pattern instanceof IsComparison) {
-        return new BinaryExpression($expression, $pattern->operator, $pattern->value);
+        $temp= new Variable($codegen->symbol());
+        return new BinaryExpression(
+          new InvokeExpression(
+            new Literal('is_numeric'),
+            [new Braced(new Assignment($temp, '=', $expression))]
+          ),
+          '&&',
+          new BinaryExpression($temp, $pattern->operator, $pattern->value)
+        );
       } else if ($pattern instanceof IsNullable) {
         $temp= new Variable($codegen->symbol());
         return new BinaryExpression(

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -164,8 +164,6 @@ class IsOperator implements Extension {
     });
 
     $match= function($codegen, $expression, $pattern) use(&$match) {
-      // \util\cmd\Console::writeLine('[...] is ', $pattern);
-
       if ($pattern instanceof IsLiteral) {
         $literal= $pattern->literal();
         if ('mixed' === $literal) {

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -14,6 +14,7 @@ use lang\ast\nodes\{
   MatchExpression,
   OffsetExpression,
   ScopeExpression,
+  UnpackExpression,
   Variable
 };
 use lang\ast\syntax\Extension;
@@ -80,9 +81,17 @@ class IsOperator implements Extension {
         $r= new IsArrayStructure();
         $parse->forward();
         if (']' !== $parse->token->value) do {
+
+          // Bind rest of array via `... $rest` vs. discarding it
           if ('...' === $parse->token->value) {
-            $r->rest= true;
             $parse->forward();
+            if ('variable' === $parse->token->kind) {
+              $parse->forward();
+              $r->rest= new Variable($parse->token->value);
+              $parse->forward();
+            } else {
+              $r->rest= true;
+            }
             break;
           }
 
@@ -284,14 +293,34 @@ class IsOperator implements Extension {
             new Literal((string)sizeof($pattern->patterns))
           )
         );
+        $matched= new ArrayLiteral([]);
+        $null= new Literal('null');
         foreach ($pattern->patterns as $key => $p) {
           $offset= new Literal((string)$key);
+          $matched->values[]= [$offset, $null];
           $compound= new BinaryExpression($compound, '&&', new BinaryExpression(
             new InvokeExpression(new Literal('array_key_exists'), [$offset, $use]),
             '&&',
             $match($codegen, new OffsetExpression($use, $offset), $p),
           ));
         }
+
+        // array_diff_key() removes entries for keys in the second argument,
+        // unpacking re-keys lists but keeps map key-value pairs intact.
+        if ($pattern->rest instanceof Variable) {
+          $compound= new BinaryExpression($compound, '&&', new Braced(new BinaryExpression(
+            new Braced(new Assignment($pattern->rest, '=', $pattern->patterns
+              ? new ArrayLiteral([[
+                null,
+                new UnpackExpression(new InvokeExpression(new Literal('array_diff_key'), [$use, $matched]))
+              ]])
+              : $use
+            )),
+            '||',
+            new Literal('true')
+          )));
+        }
+
         return $compound;
       }
 

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -125,7 +125,7 @@ class IsOperator implements Extension {
     });
 
     $language->prefix('match', 0, function($parse, $token) use($pattern) {
-      $patterns= false;
+      $patterns= null;
       $condition= null;
 
       if ('(' === $parse->token->value) {
@@ -136,7 +136,15 @@ class IsOperator implements Extension {
         // See https://wiki.php.net/rfc/pattern-matching#match_is_placement
         if ('is' === $parse->token->value) {
           $parse->forward();
-          $patterns= true;
+
+          $true= new Literal('true');
+          if ($condition instanceof Variable) {
+            $patterns= $condition;
+            $condition= $true;
+          } else {
+            $patterns= new Variable('Ṁ');
+            $condition= new BinaryExpression(new Braced(new Assignment($patterns, '=', $condition)), '||', $true);
+          }
         }
       }
 
@@ -149,7 +157,7 @@ class IsOperator implements Extension {
           $parse->expecting('=>', 'match');
           $default= $this->expression($parse, 0);
         } else if ($patterns) {
-          $match= [new PatternMatch($condition, $pattern($parse, $this), $parse->token->line)];
+          $match= [new PatternMatch($patterns, $pattern($parse, $this), $parse->token->line)];
           $parse->expecting('=>', 'match');
           $cases[]= new MatchCondition($match, $this->expression($parse, 0), $parse->token->line);
         } else {
@@ -167,7 +175,7 @@ class IsOperator implements Extension {
       }
       $parse->expecting('}', 'match');
 
-      return new MatchExpression($patterns ? null : $condition, $cases, $default, $token->line);
+      return new MatchExpression($condition, $cases, $default, $token->line);
     });
 
     $match= function($codegen, $expression, $pattern) use(&$match) {

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -13,6 +13,7 @@ use lang\ast\nodes\{
   MatchExpression,
   OffsetExpression,
   ScopeExpression,
+  TernaryExpression,
   Variable
 };
 use lang\ast\syntax\Extension;
@@ -196,11 +197,12 @@ class IsOperator implements Extension {
           $match($codegen, $temp, $pattern->element)
         );
       } else if ($pattern instanceof IsBinding) {
-        return new BinaryExpression(
-          new Literal('true'),
-          '|',
-          new Braced(new Assignment($pattern->variable, '=', $expression))
-        );
+        $true= new Literal('true');
+        return new Braced(new TernaryExpression(
+          new Braced(new Assignment($pattern->variable, '=', $expression)),
+          $true,
+          $true
+        ));
       } else if ($pattern instanceof IsCompound) {
         $s= sizeof($pattern->patterns);
         if (1 === $s) return $match($codegen, $expression, $pattern->patterns[0]);

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -47,11 +47,11 @@ class IsOperator implements Extension {
           $parse->expecting(')', 'object structure');
         } else if ('::' === $parse->token->value) {
           $parse->forward();
-          $r= new IsComparable(new ScopeExpression($r->literal(), new Literal($parse->token->value)), '===');
+          $r= new IsComparison(new ScopeExpression($r->literal(), new Literal($parse->token->value)), '===');
           $parse->forward();
         }
       } else if ('string' === $parse->token->kind || 'integer' === $parse->token->kind || 'decimal' === $parse->token->kind) {
-        $r= new IsComparable(new Literal($parse->token->value), '===');
+        $r= new IsComparison(new Literal($parse->token->value), '===');
         $parse->forward();
       } else if ('variable' === $parse->token->kind) {
         $parse->forward();
@@ -60,7 +60,7 @@ class IsOperator implements Extension {
       } else if ('>' === $parse->token->value || '>=' === $parse->token->value || '<' === $parse->token->value || '<=' === $parse->token->value) {
         $operator= $parse->token->value;
         $parse->forward();
-        $r= new IsComparable(new Literal($parse->token->value), $operator);
+        $r= new IsComparison(new Literal($parse->token->value), $operator);
         $parse->forward();
       } else if ('[' === $parse->token->value) {
         $r= new IsArrayStructure();
@@ -83,7 +83,7 @@ class IsOperator implements Extension {
         $parse->expecting(']', 'array structure');
       } else if ('^' === $parse->token->value) {
         $parse->forward();
-        $r= new IsComparable($types->expression($parse, 0), '===');
+        $r= new IsComparison($types->expression($parse, 0), '===');
       } else {
         $parse->expecting('a type or literal', 'is');
         return null;
@@ -116,7 +116,7 @@ class IsOperator implements Extension {
         }
       } else if ($pattern instanceof IsValue) {
         return new InstanceOfExpression($expression, $pattern);
-      } else if ($pattern instanceof IsComparable) {
+      } else if ($pattern instanceof IsComparison) {
         return new BinaryExpression($expression, $pattern->operator, $pattern->value);
       } else if ($pattern instanceof IsNullable) {
         $temp= new Variable($codegen->symbol());

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -150,13 +150,13 @@ class IsOperator implements Extension {
           new BinaryExpression(
             new InvokeExpression(new Literal('sizeof'), [$temp]),
             $pattern->rest ? '>=' : '===',
-            new Literal(sizeof($pattern->patterns))
+            new Literal((string)sizeof($pattern->patterns))
           )
         );
         foreach ($pattern->patterns as $key => $p) {
           $compound= new BinaryExpression($compound, '&&', $match(
             $codegen,
-            new Braced(new BinaryExpression(new OffsetExpression($temp, new Literal($key)), '??', $null)),
+            new Braced(new BinaryExpression(new OffsetExpression($temp, new Literal((string)$key)), '??', $null)),
             $p
           ));
         }

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -125,6 +125,8 @@ class IsOperator implements Extension {
     });
 
     $language->prefix('match', 0, function($parse, $token) use($pattern) {
+      static $id= 0;
+
       $patterns= null;
       $condition= null;
 
@@ -148,6 +150,7 @@ class IsOperator implements Extension {
         }
       }
 
+      $is= false;
       $default= null;
       $cases= [];
       $parse->expecting('{', 'match');
@@ -156,8 +159,10 @@ class IsOperator implements Extension {
           $parse->forward();
           $parse->expecting('=>', 'match');
           $default= $this->expression($parse, 0);
-        } else if ($patterns) {
-          $match= [new PatternMatch($patterns, $pattern($parse, $this), $parse->token->line)];
+        } else if ('is' === $parse->token->value) {
+          $is= true;
+          $parse->forward();
+          $match= [new PatternMatch(null, $pattern($parse, $this), $parse->token->line)];
           $parse->expecting('=>', 'match');
           $cases[]= new MatchCondition($match, $this->expression($parse, 0), $parse->token->line);
         } else {
@@ -174,6 +179,26 @@ class IsOperator implements Extension {
         }
       }
       $parse->expecting('}', 'match');
+
+      // If one of the branches contains an `is` match, rewrite the statement
+      if ($is) {
+        $patterns= new Variable('Ϻ'.($id++));
+        $condition= new BinaryExpression(
+          new Braced(new Assignment($patterns, '=', $condition)),
+          '||',
+          new Literal('true')
+        );
+
+        foreach ($cases as $case) {
+          foreach ($case->expressions as &$match) {
+            if ($match instanceof PatternMatch) {
+              $match->expression= $patterns;
+            } else {
+              $match= new BinaryExpression($match, '===', $patterns);
+            }
+          }
+        }
+      }
 
       return new MatchExpression($condition, $cases, $default, $token->line);
     });

--- a/src/main/php/lang/ast/syntax/php/IsOperator.class.php
+++ b/src/main/php/lang/ast/syntax/php/IsOperator.class.php
@@ -178,21 +178,30 @@ class IsOperator implements Extension {
       } else if ($pattern instanceof IsIdentical) {
         return new BinaryExpression($expression, '===', $pattern->value);
       } else if ($pattern instanceof IsComparison) {
-        $temp= new Variable($codegen->symbol());
+        if ($expression instanceof Variable) {
+          $use= $init= $expression;
+        } else {
+          $use= new Variable($codegen->symbol());
+          $init= new Braced(new Assignment($use, '=', $expression));
+        }
+
         return new BinaryExpression(
-          new InvokeExpression(
-            new Literal('is_numeric'),
-            [new Braced(new Assignment($temp, '=', $expression))]
-          ),
+          new InvokeExpression(new Literal('is_numeric'), [$init]),
           '&&',
-          new BinaryExpression($temp, $pattern->operator, $pattern->value)
+          new BinaryExpression($use, $pattern->operator, $pattern->value)
         );
       } else if ($pattern instanceof IsNullable) {
-        $temp= new Variable($codegen->symbol());
+        if ($expression instanceof Variable) {
+          $use= $init= $expression;
+        } else {
+          $use= new Variable($codegen->symbol());
+          $init= new Braced(new Assignment($use, '=', $expression));
+        }
+
         return new BinaryExpression(
-          new BinaryExpression(new Literal('null'), '===', new Braced(new Assignment($temp, '=', $expression))),
+          new BinaryExpression(new Literal('null'), '===', $init),
           '||',
-          $match($codegen, $temp, $pattern->element)
+          $match($codegen, $use, $pattern->element)
         );
       } else if ($pattern instanceof IsBinding) {
         $true= new Literal('true');
@@ -205,20 +214,29 @@ class IsOperator implements Extension {
         $s= sizeof($pattern->patterns);
         if (1 === $s) return $match($codegen, $expression, $pattern->patterns[0]);
 
-        $temp= new Variable($codegen->symbol());
-        $compound= $match($codegen, new Braced(new Assignment($temp, '=', $expression)), $pattern->patterns[0]);
+        if ($expression instanceof Variable) {
+          $use= $init= $expression;
+        } else {
+          $use= new Variable($codegen->symbol());
+          $init= new Braced(new Assignment($use, '=', $expression));
+        }
+        $compound= $match($codegen, $init, $pattern->patterns[0]);
         for ($i= 1, $op= $pattern->operator.$pattern->operator; $i < $s; $i++) {
-          $compound= new BinaryExpression($compound, $op, $match($codegen, $temp, $pattern->patterns[$i]));
+          $compound= new BinaryExpression($compound, $op, $match($codegen, $use, $pattern->patterns[$i]));
         }
         return new Braced($compound);
       } else if ($pattern instanceof IsArrayStructure) {
-        $null= new Literal('null');
-        $temp= new Variable($codegen->symbol());
+        if ($expression instanceof Variable) {
+          $use= $init= $expression;
+        } else {
+          $use= new Variable($codegen->symbol());
+          $init= new Assignment($use, '=', $expression);
+        }
         $compound= new BinaryExpression(
-          new InvokeExpression(new Literal('is_array'), [new Assignment($temp, '=', $expression)]),
+          new InvokeExpression(new Literal('is_array'), [$init]),
           '&&',
           new BinaryExpression(
-            new InvokeExpression(new Literal('sizeof'), [$temp]),
+            new InvokeExpression(new Literal('sizeof'), [$use]),
             $pattern->rest ? '>=' : '===',
             new Literal((string)sizeof($pattern->patterns))
           )
@@ -226,19 +244,24 @@ class IsOperator implements Extension {
         foreach ($pattern->patterns as $key => $p) {
           $offset= new Literal((string)$key);
           $compound= new BinaryExpression($compound, '&&', new BinaryExpression(
-            new InvokeExpression(new Literal('array_key_exists'), [$offset, $temp]),
+            new InvokeExpression(new Literal('array_key_exists'), [$offset, $use]),
             '&&',
-            $match($codegen, new OffsetExpression($temp, $offset), $p),
+            $match($codegen, new OffsetExpression($use, $offset), $p),
           ));
         }
         return $compound;
       } else if ($pattern instanceof IsObjectStructure) {
-        $temp= new Variable($codegen->symbol());
-        $compound= new InstanceOfExpression(new Braced(new Assignment($temp, '=', $expression)), $pattern->type);
+        if ($expression instanceof Variable) {
+          $use= $init= $expression;
+        } else {
+          $use= new Variable($codegen->symbol());
+          $init= new Braced(new Assignment($use, '=', $expression));
+        }
+        $compound= new InstanceOfExpression($init, $pattern->type);
         foreach ($pattern->patterns as $key => $p) {
           $compound= new BinaryExpression($compound, '&&', $match(
             $codegen,
-            new InstanceExpression($temp, new Literal($key)),
+            new InstanceExpression($use, new Literal($key)),
             $p
           ));
         }

--- a/src/main/php/lang/ast/syntax/php/PatternMatch.class.php
+++ b/src/main/php/lang/ast/syntax/php/PatternMatch.class.php
@@ -1,0 +1,14 @@
+<?php namespace lang\ast\syntax\php;
+
+use lang\ast\Node;
+
+class PatternMatch extends Node {
+  public $kind= 'is';
+  public $expression, $pattern;
+
+  public function __construct($expression, $pattern= null, $line= -1) {
+    $this->expression= $expression;
+    $this->pattern= $pattern;
+    $this->line= $line;
+  }
+}

--- a/src/test/php/lang/ast/syntax/php/unittest/ArrayStructureTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/ArrayStructureTest.class.php
@@ -24,6 +24,7 @@ class ArrayStructureTest extends EmittingTest {
     yield ['[] is [1, 2]', false];
     yield ['null is [1, 2]', false];
 
+    yield ['[1] is [...]', true];
     yield ['[1, 2] is [...]', true];
     yield ['[1, 2] is [1, 2, ...]', true];
     yield ['[1, 2, 3] is [1, 2, ...]', true];
@@ -37,6 +38,11 @@ class ArrayStructureTest extends EmittingTest {
     yield ['["one" => 1] is ["one" => 1, ...]', true];
     yield ['["one" => 1, "two" => 2] is ["one" => 1, ...]', true];
     yield ['["two" => 2] is ["one" => 1, ...]', false];
+
+    yield ['[2] is [0 => 2]', true];
+    yield ['[2] is ["0" => 2]', true];
+    yield ['[1] is [0 => 2]', false];
+    yield ['[1] is ["0" => 2]', false];
 
     yield ['[1, 2] is [1, 2|3]', true];
     yield ['[1, 3] is [1, 2|3]', true];

--- a/src/test/php/lang/ast/syntax/php/unittest/ArrayStructureTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/ArrayStructureTest.class.php
@@ -38,6 +38,7 @@ class ArrayStructureTest extends EmittingTest {
     yield ['["one" => 1] is ["one" => 1, ...]', true];
     yield ['["one" => 1, "two" => 2] is ["one" => 1, ...]', true];
     yield ['["two" => 2] is ["one" => 1, ...]', false];
+    yield ['["two" => 2] is ["one" => null]', false];
 
     yield ['[2] is [0 => 2]', true];
     yield ['[2] is ["0" => 2]', true];

--- a/src/test/php/lang/ast/syntax/php/unittest/ArrayStructureTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/ArrayStructureTest.class.php
@@ -1,0 +1,59 @@
+<?php namespace lang\ast\syntax\php\unittest;
+
+use lang\ast\unittest\emit\EmittingTest;
+use test\{Assert, Test, Values};
+
+/** @see https://wiki.php.net/rfc/pattern-matching#array_structure_pattern */
+class ArrayStructureTest extends EmittingTest {
+
+  /** @return iterable */
+  private function fixtures() {
+    yield ['[] is []', true];
+    yield ['[1, 2] is []', false];
+    yield ['null is []', false];
+
+    yield ['[0] is [0]', true];
+    yield ['[1] is [1]', true];
+    yield ['[2] is [1]', false];
+    yield ['[] is [1]', false];
+    yield ['[1, 2] is [1]', false];
+    yield ['null is [1]', false];
+
+    yield ['[1, 2] is [1, 2]', true];
+    yield ['[1] is [1, 2]', false];
+    yield ['[] is [1, 2]', false];
+    yield ['null is [1, 2]', false];
+
+    yield ['[1, 2] is [...]', true];
+    yield ['[1, 2] is [1, 2, ...]', true];
+    yield ['[1, 2, 3] is [1, 2, ...]', true];
+    yield ['[0, 1, 2] is [0, 1, ...]', true];
+
+    yield ['["one" => 1, "two" => 2] is ["one" => 1, "two" => 2]', true];
+    yield ['["two" => 2, "one" => 1] is ["one" => 1, "two" => 2]', true];
+    yield ['[1, 2] is ["one" => 1, "two" => 2]', false];
+    yield ['null is ["one" => 1, "two" => 2]', false];
+
+    yield ['["one" => 1] is ["one" => 1, ...]', true];
+    yield ['["one" => 1, "two" => 2] is ["one" => 1, ...]', true];
+    yield ['["two" => 2] is ["one" => 1, ...]', false];
+
+    yield ['[1, 2] is [1, 2|3]', true];
+    yield ['[1, 3] is [1, 2|3]', true];
+    yield ['[1, 2, 3] is [1, 2|3]', false];
+    yield ['[1, 2] is [1, >=0 & <=10]', true];
+
+    yield ['[1, 2] is [1, int|string]', true];
+    yield ['[1, "2"] is [1, int|string]', true];
+    yield ['[1, null] is [1, int|string]', false];
+  }
+
+  #[Test, Values(from: 'fixtures')]
+  public function test($expr, $expected) {
+    Assert::equals($expected, $this->run('class %T {
+      public function run() {
+        return '.$expr.';
+      }
+    }'));
+  }
+}

--- a/src/test/php/lang/ast/syntax/php/unittest/CompoundTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/CompoundTest.class.php
@@ -15,9 +15,15 @@ class CompoundTest extends EmittingTest {
     yield ['1.5 is int|float', true];
     yield ['"test" is int|float', false];
 
+    yield ['1 is int & 1', true];
+    yield ['2 is int & (1|2)', true];
+    yield ['3 is int & float', false];
+    yield ['"test" is string & "success"', false];
+
     yield ['"test" is "success"|"failure"', false];
     yield ['"success" is "success"|"failure"', true];
     yield ['"success" is "success"|"failure"|null', true];
+    yield ['"success" is "success"|"failure"|"running"', true];
 
     yield ['[] is ""|array', true];
     yield ['[] is array|""', true];
@@ -29,8 +35,15 @@ class CompoundTest extends EmittingTest {
     yield ['new Date() is IteratorAggregate|Runnable', false];
 
     yield ['$this is IteratorAggregate&Runnable', true];
+    yield ['$this is (IteratorAggregate&Runnable)', true];
     yield ['null is IteratorAggregate&Runnable', false];
     yield ['new Date() is IteratorAggregate&Runnable', false];
+
+    yield ['$this is null|(IteratorAggregate&Runnable)', true];
+    yield ['null is null|(IteratorAggregate&Runnable)', true];
+    yield ['$this is (IteratorAggregate&Runnable)|null', true];
+    yield ['null is (IteratorAggregate&Runnable)|null', true];
+    yield ['null is IteratorAggregate&(Runnable|null)', false];
 
     yield ['1 is null | >0 & <10', true];
     yield ['null is null | >0 & <10', true];

--- a/src/test/php/lang/ast/syntax/php/unittest/CompoundTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/CompoundTest.class.php
@@ -18,6 +18,7 @@ class CompoundTest extends EmittingTest {
     yield ['1 is int & 1', true];
     yield ['2 is int & (1|2)', true];
     yield ['3 is int & float', false];
+    yield ['3 is 1|2|3', true];
     yield ['"test" is string & "success"', false];
 
     yield ['"test" is "success"|"failure"', false];

--- a/src/test/php/lang/ast/syntax/php/unittest/CompoundTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/CompoundTest.class.php
@@ -1,0 +1,72 @@
+<?php namespace lang\ast\syntax\php\unittest;
+
+use lang\ast\unittest\emit\EmittingTest;
+use test\{Assert, Test, Values};
+
+/** @see https://wiki.php.net/rfc/pattern-matching#compound_patterns */
+class CompoundTest extends EmittingTest {
+
+  /** @return iterable */
+  private function fixtures() {
+    yield ['1 is >0 & <10', true];
+    yield ['0 is >0 & <10', false];
+
+    yield ['1 is int|float', true];
+    yield ['1.5 is int|float', true];
+    yield ['"test" is int|float', false];
+
+    yield ['"test" is "success"|"failure"', false];
+    yield ['"success" is "success"|"failure"', true];
+    yield ['"success" is "success"|"failure"|null', true];
+
+    yield ['[] is ""|array', true];
+    yield ['[] is array|""', true];
+    yield ['[] is array|null', true];
+    yield ['[] is null|array', true];
+
+    yield ['$this is array|Traversable', true];
+    yield ['$this is IteratorAggregate|Runnable', true];
+    yield ['new Date() is IteratorAggregate|Runnable', false];
+
+    yield ['$this is IteratorAggregate&Runnable', true];
+    yield ['null is IteratorAggregate&Runnable', false];
+    yield ['new Date() is IteratorAggregate&Runnable', false];
+
+    yield ['1 is null | >0 & <10', true];
+    yield ['null is null | >0 & <10', true];
+    yield ['0 is null | >0 & <10', false];
+  }
+
+  #[Test, Values(from: 'fixtures')]
+  public function test($expr, $expected) {
+    Assert::equals($expected, $this->run('
+      use util\\Date, lang\\Runnable, lang\\ast\\syntax\\php\\unittest\\Point; 
+
+      class %T implements Runnable, IteratorAggregate {
+
+      public function getIterator(): Traversable {
+        yield true;
+      }
+
+      public function run() {
+        return '.$expr.';
+      }
+    }'));
+  }
+
+  #[Test]
+  public function expression_evaluated_once() {
+    Assert::equals([true, 1], $this->run('class %T {
+      public function run() {
+        $evaluated= 0;
+        $expr= function() use(&$evaluated) {
+          $evaluated++;
+          return 1;
+        };
+
+        $result= $expr() is >0 & <2;
+        return [$result, $evaluated];
+      }
+    }'));
+  }
+}

--- a/src/test/php/lang/ast/syntax/php/unittest/CompoundTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/CompoundTest.class.php
@@ -29,6 +29,7 @@ class CompoundTest extends EmittingTest {
     yield ['[] is array|""', true];
     yield ['[] is array|null', true];
     yield ['[] is null|array', true];
+    yield ['[] is [] & [...]', true];
 
     yield ['$this is array|Traversable', true];
     yield ['$this is IteratorAggregate|Runnable', true];

--- a/src/test/php/lang/ast/syntax/php/unittest/IsOperatorTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/IsOperatorTest.class.php
@@ -49,21 +49,23 @@ class IsOperatorTest extends EmittingTest {
     }', $arg));
   }
 
-  #[Test]
-  public function match_is_condition_evaluated_once() {
-    Assert::equals(['one', 1], $this->run('class %T {
-      public function run() {
+  #[Test, Values([[0, 'zero'], [1, 'one'], [null, '<null>'], ['test', '<default>']])]
+  public function match_is_condition_evaluated_once($arg, $expected) {
+    Assert::equals([$expected, 1], $this->run('class %T {
+      public function run($return) {
         $invoked= 0;
-        $arg= function() use(&$invoked) {
+        $arg= function() use(&$invoked, $return) {
           $invoked++;
-          return 1;
+          return $return;
         };
         return match ($arg()) {
-          is 0 => ["zero", $invoked],
-          is 1 => ["one", $invoked],
+          is 0       => ["zero", $invoked],
+          is 1 & int => ["one", $invoked],
+          null       => ["<null>", $invoked],
+          default    => ["<default>", $invoked],
         };
       }
-    }'));
+    }', $arg));
   }
 
   #[Test, Values([[1, true], ["one", true], [null, false]])]

--- a/src/test/php/lang/ast/syntax/php/unittest/IsOperatorTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/IsOperatorTest.class.php
@@ -36,13 +36,14 @@ class IsOperatorTest extends EmittingTest {
     }', $arg));
   }
 
-  #[Test, Values([[1, 'int'], ['test', 'string']])]
+  #[Test, Values([[1, 'int'], ['', 'string'], ['test', 'string'], [null, 'undefined']])]
   public function match_is_variant($arg, $expected) {
     Assert::equals($expected, $this->run('class %T {
-      public function run(string|int $arg) {
-        return match ($arg) is {
-          string => "string",
-          int => "int",
+      public function run(?string|int $arg) {
+        return match ($arg) {
+          is string => "string",
+          is int => "int",
+          null => "undefined",
         };
       }
     }', $arg));
@@ -57,9 +58,9 @@ class IsOperatorTest extends EmittingTest {
           $invoked++;
           return 1;
         };
-        return match ($arg()) is {
-          0 => ["zero", $invoked],
-          1 => ["one", $invoked],
+        return match ($arg()) {
+          is 0 => ["zero", $invoked],
+          is 1 => ["one", $invoked],
         };
       }
     }'));

--- a/src/test/php/lang/ast/syntax/php/unittest/IsOperatorTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/IsOperatorTest.class.php
@@ -7,52 +7,54 @@ class IsOperatorTest extends EmittingTest {
 
   #[Test]
   public function is_mixed_type() {
-    $r= $this->run('class %T {
+    Assert::true($this->run('class %T {
       public function run() {
         return $this is mixed;
       }
-    }');
-
-    Assert::true($r);
+    }'));
   }
 
   #[Test]
   public function precedence() {
-    $r= $this->run('class %T {
+    Assert::equals('string <Test>', $this->run('class %T {
       public function run() {
         $arg= "Test";
         return $arg is string ? sprintf("string <%s>", $arg) : typeof($arg)->literal();
       }
-    }');
-
-    Assert::equals('string <Test>', $r);
+    }'));
   }
 
   #[Test, Values([[1, 'int'], ['test', 'string']])]
   public function with_match_statement($arg, $expected) {
-    $r= $this->run('class %T {
+    Assert::equals($expected, $this->run('class %T {
       public function run(string|int $arg) {
         return match {
           $arg is string => "string",
           $arg is int => "int",
         };
       }
-    }', $arg);
-
-    Assert::equals($expected, $r);
+    }', $arg));
   }
 
   #[Test, Values([[1, 'int'], ['test', 'string']])]
   public function match_is_variant($arg, $expected) {
-    $r= $this->run('class %T {
+    Assert::equals($expected, $this->run('class %T {
       public function run(string|int $arg) {
         return match ($arg) is {
           string => "string",
           int => "int",
         };
       }
-    }', $arg);
+    }', $arg));
+  }
 
-    Assert::equals($expected, $r);
+  #[Test, Values([[1, true], ["one", true], [null, false]])]
+  public function as_closure($arg, $expected) {
+    Assert::equals($expected, $this->run('class %T {
+      public function run($arg) {
+        $f= fn($arg) => $arg is int|string;
+        return $f($arg);
+      }
+    }', $arg));
   }
 }

--- a/src/test/php/lang/ast/syntax/php/unittest/IsOperatorTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/IsOperatorTest.class.php
@@ -48,6 +48,23 @@ class IsOperatorTest extends EmittingTest {
     }', $arg));
   }
 
+  #[Test]
+  public function match_is_condition_evaluated_once() {
+    Assert::equals(['one', 1], $this->run('class %T {
+      public function run() {
+        $invoked= 0;
+        $arg= function() use(&$invoked) {
+          $invoked++;
+          return 1;
+        };
+        return match ($arg()) is {
+          0 => ["zero", $invoked],
+          1 => ["one", $invoked],
+        };
+      }
+    }'));
+  }
+
   #[Test, Values([[1, true], ["one", true], [null, false]])]
   public function as_closure($arg, $expected) {
     Assert::equals($expected, $this->run('class %T {

--- a/src/test/php/lang/ast/syntax/php/unittest/IsOperatorTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/IsOperatorTest.class.php
@@ -41,4 +41,18 @@ class IsOperatorTest extends EmittingTest {
 
     Assert::equals($expected, $r);
   }
+
+  #[Test, Values([[1, 'int'], ['test', 'string']])]
+  public function match_is_variant($arg, $expected) {
+    $r= $this->run('class %T {
+      public function run(string|int $arg) {
+        return match ($arg) is {
+          string => "string",
+          int => "int",
+        };
+      }
+    }', $arg);
+
+    Assert::equals($expected, $r);
+  }
 }

--- a/src/test/php/lang/ast/syntax/php/unittest/LiteralTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/LiteralTest.class.php
@@ -1,0 +1,39 @@
+<?php namespace lang\ast\syntax\php\unittest;
+
+use lang\ast\unittest\emit\EmittingTest;
+use test\{Assert, Test, Values};
+
+/** @see https://wiki.php.net/rfc/pattern-matching#literal_pattern */
+class LiteralTest extends EmittingTest {
+
+  /** @return iterable */
+  private function fixtures() {
+    yield ['"test" is "test"', true];
+    yield ['true is true', true];
+    yield ['false is false', true];
+    yield ['null is null', true];
+    yield ['1 is 1', true];
+    yield ['1.5 is 1.5', true];
+
+    yield ['null is "test"', false];
+    yield ['0 is ""', false];
+    yield ['0 is "0"', false];
+    yield ['1 is "1"', false];
+    yield ['true is 1', false];
+    yield ['false is 0', false];
+
+    yield ['0 is self::ZERO', true];
+    yield ['1 is self::ZERO', false];
+  }
+
+  #[Test, Values(from: 'fixtures')]
+  public function test($expr, $expected) {
+    Assert::equals($expected, $this->run('class %T {
+      const ZERO= 0;
+
+      public function run() {
+        return '.$expr.';
+      }
+    }'));
+  }
+}

--- a/src/test/php/lang/ast/syntax/php/unittest/NumericComparisonTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/NumericComparisonTest.class.php
@@ -1,0 +1,32 @@
+<?php namespace lang\ast\syntax\php\unittest;
+
+use lang\ast\unittest\emit\EmittingTest;
+use test\{Assert, Test, Values};
+
+/** @see https://wiki.php.net/rfc/pattern-matching#numeric_comparison_pattern */
+class NumericComparisonTest extends EmittingTest {
+
+  /** @return iterable */
+  private function fixtures() {
+    yield ['1 is >0', true];
+    yield ['1 is >=1', true];
+    yield ['1 is <=1', true];
+    yield ['0 is <1', true];
+    yield ['1 is <1', false];
+
+    yield ['1.0 is >0.0', true];
+    yield ['1.0 is >=1.0', true];
+    yield ['1.0 is <=1.0', true];
+    yield ['0.0 is <1.0', true];
+    yield ['1.0 is <1.0', false];
+  }
+
+  #[Test, Values(from: 'fixtures')]
+  public function test($expr, $expected) {
+    Assert::equals($expected, $this->run('class %T {
+      public function run() {
+        return '.$expr.';
+      }
+    }'));
+  }
+}

--- a/src/test/php/lang/ast/syntax/php/unittest/NumericComparisonTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/NumericComparisonTest.class.php
@@ -20,6 +20,9 @@ class NumericComparisonTest extends EmittingTest {
     yield ['0.0 is <1.0', true];
     yield ['1.0 is <1.0', false];
 
+    yield ['0 is <PHP_INT_MAX', true];
+    yield ['PHP_INT_MAX is >0', true];
+
     yield ['"1" is >0', true];
     yield ['"1e2" is >=100', true];
     yield ['"3.141" is >3 & <4', true];

--- a/src/test/php/lang/ast/syntax/php/unittest/NumericComparisonTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/NumericComparisonTest.class.php
@@ -19,6 +19,15 @@ class NumericComparisonTest extends EmittingTest {
     yield ['1.0 is <=1.0', true];
     yield ['0.0 is <1.0', true];
     yield ['1.0 is <1.0', false];
+
+    yield ['"1" is >0', true];
+    yield ['"1e2" is >=100', true];
+    yield ['"3.141" is >3 & <4', true];
+
+    yield ['null is >0', false];
+    yield ['[] is >0', false];
+    yield ['"test" is >0', false];
+    yield ['((object)[]) is >0', false];
   }
 
   #[Test, Values(from: 'fixtures')]

--- a/src/test/php/lang/ast/syntax/php/unittest/ObjectStructureTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/ObjectStructureTest.class.php
@@ -1,0 +1,40 @@
+<?php namespace lang\ast\syntax\php\unittest;
+
+use lang\ast\unittest\emit\EmittingTest;
+use test\{Assert, Test, Values};
+
+/** @see https://wiki.php.net/rfc/pattern-matching#object_pattern */
+class ObjectStructureTest extends EmittingTest {
+
+  /** @return iterable */
+  private function fixtures() {
+    yield ['new Point(1, 2, 0) is Point', true];
+    yield ['$this is Point', false];
+    yield ['null is Point', false];
+
+    yield ['new Point(1, 2, 0) is Point(x: 1)', true];
+    yield ['new Point(1, 2, 0) is Point(y: 2)', true];
+    yield ['new Point(1, 2, 0) is Point(z: 0)', true];
+    yield ['new Point(1, 2, 0) is Point(x: 1, y: 2)', true];
+    yield ['new Point(1, 2, 0) is Point(x: 1, y: 2, z: 0)', true];
+    yield ['new Point(1, 2, 3) is Point(x: 1, y: 2, z: 0)', false];
+    yield ['$this is Point(x: 1, y: 2)', false];
+    yield ['null is Point(x: 1, y: 2)', false];
+
+    yield ['new Point(1, 2) is Point(x: 1, y: 2, z: >=0)', true];
+    yield ['new Point(1, 2) is Point(x: 1, y: 2|3)', true];
+    yield ['new Point(1, 2) is Point(x: 1, y: mixed)', true];
+
+    yield ['new Point(1, 2) is Point(x: 1)&Value', true];
+    yield ['new Point(1, 2) is Point(x: 1)|null', true];
+  }
+
+  #[Test, Values(from: 'fixtures')]
+  public function test($expr, $expected) {
+    Assert::equals($expected, $this->run('use lang\\Value, lang\\ast\\syntax\\php\\unittest\\Point; class %T {
+      public function run() {
+        return '.$expr.';
+      }
+    }'));
+  }
+}

--- a/src/test/php/lang/ast/syntax/php/unittest/Point.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/Point.class.php
@@ -1,0 +1,38 @@
+<?php namespace lang\ast\syntax\php\unittest;
+
+use lang\Value;
+use util\Objects;
+
+class Point implements Value {
+  public $x, $y, $z;
+
+  /** Creates a new point */
+  public function __construct(int $x, int $y, int $z= 0) {
+    $this->x= $x;
+    $this->y= $y;
+    $this->z= $z;
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'P'.$this->x.','.$this->y.','.$this->z;
+  }
+
+  /** @return string */
+  public function toString() {
+    return namoef($this).'('.$this->x.', '.$this->y.', '.$this->z.')';
+  }
+
+  /**
+   * Comparison
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare([$this->x, $this->y, $this->z], [$value->x, $value->y, $value->z])
+      : 1
+    ;
+  }
+}

--- a/src/test/php/lang/ast/syntax/php/unittest/TypeMatchingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/TypeMatchingTest.class.php
@@ -3,6 +3,7 @@
 use lang\ast\unittest\emit\EmittingTest;
 use test\{Assert, Test, Values};
 
+/** @see https://wiki.php.net/rfc/pattern-matching#type_pattern */
 class TypeMatchingTest extends EmittingTest {
 
   /** @return iterable */
@@ -73,20 +74,12 @@ class TypeMatchingTest extends EmittingTest {
 
     yield ['new Date() is Date', true];
     yield ['$this is IteratorAggregate', true];
+    yield ['$this is Runnable', true];
     yield ['$this is Date', false];
-
-    yield ['$this is IteratorAggregate&Runnable', true];
-    yield ['new Date() is IteratorAggregate&Runnable', false];
-    yield ['null is IteratorAggregate&Runnable', false];
 
     yield ['$this is self', true];
     yield ['new Date() is self', false];
     yield ['null is self', false];
-
-    yield ['1 is int|float', true];
-    yield ['1.5 is int|float', true];
-    yield ['"test" is int|float', false];
-    yield ['$this is array|IteratorAggregate', true];
   }
 
   #[Test, Values(from: 'fixtures')]
@@ -106,6 +99,22 @@ class TypeMatchingTest extends EmittingTest {
 
       public function run() {
         return '.$expr.';
+      }
+    }'));
+  }
+
+  #[Test]
+  public function expression_evaluated_once() {
+    Assert::equals([true, 1], $this->run('class %T {
+      public function run() {
+        $evaluated= 0;
+        $expr= function() use(&$evaluated) {
+          $evaluated++;
+          return 1;
+        };
+
+        $result= $expr() is ?int;
+        return [$result, $evaluated];
       }
     }'));
   }

--- a/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
@@ -41,7 +41,7 @@ class VariableBindingTest extends EmittingTest {
     }'));
   }
 
-  #[Test, Expect(class: NullPointerException::class, message: 'Undefined variable: z')]
+  #[Test, Expect(class: NullPointerException::class, message: '/Undefined variable(.+)z/')]
   public function delayed_binding() {
     Assert::equals([false, null], $this->run('use lang\\ast\\syntax\\php\\unittest\\Point; class %T {
       public function run() {

--- a/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\ast\syntax\php\unittest;
 
 use lang\NullPointerException;
+use lang\ast\Errors;
 use lang\ast\unittest\emit\EmittingTest;
 use test\{Assert, Test, Values, Expect};
 
@@ -68,6 +69,15 @@ class VariableBindingTest extends EmittingTest {
     }', explode(' ', $input)));
   }
 
+  #[Test, Expect(class: Errors::class, message: '/Expected "\]", have "\|"/')]
+  public function binding_may_not_be_ored() {
+    $this->run('class %T {
+      public function run() {
+        [] is [$variable | 0];
+      }
+    }');
+  }
+
   #[Test, Expect(class: NullPointerException::class, message: '/Undefined variable(.+)z/')]
   public function delayed_binding() {
     Assert::equals([false, null], $this->run('use lang\\ast\\syntax\\php\\unittest\\Point; class %T {
@@ -92,6 +102,16 @@ class VariableBindingTest extends EmittingTest {
     Assert::equals('^8.0', $this->run('class %T {
       public function run() {
         return ["require" => ["php" => "^8.0"]] is ["require" => ["php" => $version]] ? $version : null;
+      }
+    }'));
+  }
+
+  #[Test, Values(['[] is [$var]', '["test"] is [$var & int]'])]
+  public function variable_unset_when_unmatched($expr) {
+    Assert::false($this->run('class %T {
+      public function run() {
+        '.$expr.';
+        return isset($var);
       }
     }'));
   }

--- a/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
@@ -79,10 +79,19 @@ class VariableBindingTest extends EmittingTest {
   }
 
   #[Test]
-  public function nested_destructuring() {
+  public function nested_list_destructuring() {
     Assert::equals([1, 2, 3], $this->run('class %T {
       public function run() {
         return [[1, 2], 3] is [[$a, $b], $c] ? [$a, $b, $c] : null;
+      }
+    }'));
+  }
+
+  #[Test]
+  public function nested_map_destructuring() {
+    Assert::equals('^8.0', $this->run('class %T {
+      public function run() {
+        return ["require" => ["php" => "^8.0"]] is ["require" => ["php" => $version]] ? $version : null;
       }
     }'));
   }

--- a/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
@@ -31,6 +31,13 @@ class VariableBindingTest extends EmittingTest {
 
     yield ['[1, [1]] is [1, $rest] ? $rest : null', [1]];
     yield ['[1, [2], "three"] is [1, mixed, $rest] ? $rest : null', 'three'];
+    yield ['[] is [...$rest] ? $rest : null', []];
+    yield ['[1] is [int, ...$rest] ? $rest : null', []];
+    yield ['[1, 2, 3] is [...$rest] ? $rest : null', [1, 2, 3]];
+    yield ['[1, 2, 3] is [1, ...$rest] ? $rest : null', [2, 3]];
+    yield ['[1, [1]] is [int, ...$rest] ? $rest : null', [[1]]];
+    yield ['["one" => 1] is ["one" => 1, ...$rest] ? $rest : null', []];
+    yield ['["one" => 1, "two" => 2] is ["one" => 1, ...$rest] ? $rest : null', ['two' => 2]];
 
     yield ['["one" => 1, "two" => 2] is ["one" => 1, "two" => $t] ? $t : null', 2];
     yield ['["one" => 0, "two" => 2] is ["one" => 1, "two" => $t] ? $t : null', null];
@@ -57,12 +64,13 @@ class VariableBindingTest extends EmittingTest {
     }', explode(' ', $input)));
   }
 
-  #[Test, Values([['go north', 'north'], ['go south', 'south'], ['go home', null]])]
+#[Test, Values([['go north', 'north'], ['go south', 'south'], ['go home', null], ['drop it now', ['it', 'now']]])]
   public function bind_with_subpattern($input, $expected) {
     Assert::equals($expected, $this->run('class %T {
       public function run($command) {
         return match ($command) {
           is ["go", $direction & ("north"|"south"|"east"|"west")] => $direction,
+          is ["drop", ...$objects] => $objects,
           default => null,
         };
       }

--- a/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
@@ -29,6 +29,7 @@ class VariableBindingTest extends EmittingTest {
     yield ['[0, 1, 2] is [$x, $y, $z] ? [$x, $y, $z] : null', [0, 1, 2]];
 
     yield ['[1, [1]] is [1, $rest] ? $rest : null', [1]];
+    yield ['[1, [2], "three"] is [1, mixed, $rest] ? $rest : null', 'three'];
 
     yield ['["one" => 1, "two" => 2] is ["one" => 1, "two" => $t] ? $t : null', 2];
     yield ['["one" => 0, "two" => 2] is ["one" => 1, "two" => $t] ? $t : null', null];

--- a/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
@@ -28,6 +28,8 @@ class VariableBindingTest extends EmittingTest {
     yield ['[1, 2, 3] is [$x, $y, $z] ? [$x, $y, $z] : null', [1, 2, 3]];
     yield ['[0, 1, 2] is [$x, $y, $z] ? [$x, $y, $z] : null', [0, 1, 2]];
 
+    yield ['[1, [1]] is [1, $rest] ? $rest : null', [1]];
+
     yield ['["one" => 1, "two" => 2] is ["one" => 1, "two" => $t] ? $t : null', 2];
     yield ['["one" => 0, "two" => 2] is ["one" => 1, "two" => $t] ? $t : null', null];
   }

--- a/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
@@ -1,0 +1,37 @@
+<?php namespace lang\ast\syntax\php\unittest;
+
+use lang\ast\unittest\emit\EmittingTest;
+use test\{Assert, Test, Values};
+
+/** @see https://wiki.php.net/rfc/pattern-matching#variable_binding */
+class VariableBindingTest extends EmittingTest {
+
+  /** @return iterable */
+  private function fixtures() {
+    yield ['new Point(1, 2, 3) is Point(x: 1, y: 2, z: $z) ? $z : null', 3];
+    yield ['new Point(1, 2, 3) is Point(x: 0, y: 2, z: $z) ? $z : null', null];
+
+    yield ['new Point(1, 2, 3) is Point(x: $x, y: $y, z: $z) ? [$x, $y, $z] : null', [1, 2, 3]];
+    yield ['new Point(1, 2, 3) is Point(:$x, :$y, :$z) ? [$x, $y, $z] : null', [1, 2, 3]];
+
+    yield ['new Point(1, 2, 3) is Point(:$x, :$y, :$z & > 0) ? [$x, $y, $z] : null', [1, 2, 3]];
+    yield ['new Point(1, 2, 0) is Point(:$x, :$y, :$z & > 0) ? [$x, $y, $z] : null', null];
+
+    yield ['[1, 2, 3] is [1, 2, $z] ? $z : null', 3];
+    yield ['[0, 2, 3] is [1, 2, $z] ? $z : null', null];
+    yield ['[1, 2, 3] is [$x, $y, $z] ? [$x, $y, $z] : null', [1, 2, 3]];
+    yield ['[0, 1, 2] is [$x, $y, $z] ? [$x, $y, $z] : null', [0, 1, 2]];
+
+    yield ['["one" => 1, "two" => 2] is ["one" => 1, "two" => $t] ? $t : null', 2];
+    yield ['["one" => 0, "two" => 2] is ["one" => 1, "two" => $t] ? $t : null', null];
+  }
+
+  #[Test, Values(from: 'fixtures')]
+  public function test($expr, $expected) {
+    Assert::equals($expected, $this->run('use lang\\Value, lang\\ast\\syntax\\php\\unittest\\Point; class %T {
+      public function run() {
+        return '.$expr.';
+      }
+    }'));
+  }
+}

--- a/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
@@ -43,6 +43,30 @@ class VariableBindingTest extends EmittingTest {
     }'));
   }
 
+  #[Test, Values(['get apple', 'pick up apple', 'pick apple up'])]
+  public function compound_binding($input) {
+    Assert::equals('apple', $this->run('class %T {
+      public function run($command) {
+        return match ($command) is {
+          ["get", $object]|["pick", "up", $object]|["pick", $object, "up"] => $object,
+          default => null,
+        };
+      }
+    }', explode(' ', $input)));
+  }
+
+  #[Test, Values([['go north', 'north'], ['go south', 'south'], ['go home', null]])]
+  public function bind_with_subpattern($input, $expected) {
+    Assert::equals($expected, $this->run('class %T {
+      public function run($command) {
+        return match ($command) is {
+          ["go", $direction & ("north"|"south"|"east"|"west")] => $direction,
+          default => null,
+        };
+      }
+    }', explode(' ', $input)));
+  }
+
   #[Test, Expect(class: NullPointerException::class, message: '/Undefined variable(.+)z/')]
   public function delayed_binding() {
     Assert::equals([false, null], $this->run('use lang\\ast\\syntax\\php\\unittest\\Point; class %T {

--- a/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
@@ -8,12 +8,17 @@ class VariableBindingTest extends EmittingTest {
 
   /** @return iterable */
   private function fixtures() {
+    yield ['new Point(1, 2, 3) is Point(z: $z) ? $z : null', 3];
+    yield ['new Point(1, 2, 3) is Point(:$z) ? $z : null', 3];
+    yield ['new Point(1, 2, 3) is Point(z: $bound) ? $bound : null', 3];
+
     yield ['new Point(1, 2, 3) is Point(x: 1, y: 2, z: $z) ? $z : null', 3];
     yield ['new Point(1, 2, 3) is Point(x: 0, y: 2, z: $z) ? $z : null', null];
 
     yield ['new Point(1, 2, 3) is Point(x: $x, y: $y, z: $z) ? [$x, $y, $z] : null', [1, 2, 3]];
     yield ['new Point(1, 2, 3) is Point(:$x, :$y, :$z) ? [$x, $y, $z] : null', [1, 2, 3]];
 
+    yield ['new Point(1, 2, 3) is Point(:$z & ?int) ? $z : null', 3];
     yield ['new Point(1, 2, 3) is Point(:$x, :$y, :$z & > 0) ? [$x, $y, $z] : null', [1, 2, 3]];
     yield ['new Point(1, 2, 0) is Point(:$x, :$y, :$z & > 0) ? [$x, $y, $z] : null', null];
 

--- a/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
@@ -77,4 +77,13 @@ class VariableBindingTest extends EmittingTest {
       }
     }'));
   }
+
+  #[Test]
+  public function nested_destructuring() {
+    Assert::equals([1, 2, 3], $this->run('class %T {
+      public function run() {
+        return [[1, 2], 3] is [[$a, $b], $c] ? [$a, $b, $c] : null;
+      }
+    }'));
+  }
 }

--- a/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace lang\ast\syntax\php\unittest;
 
+use lang\NullPointerException;
 use lang\ast\unittest\emit\EmittingTest;
-use test\{Assert, Test, Values};
+use test\{Assert, Test, Values, Expect};
 
 /** @see https://wiki.php.net/rfc/pattern-matching#variable_binding */
 class VariableBindingTest extends EmittingTest {
@@ -36,6 +37,16 @@ class VariableBindingTest extends EmittingTest {
     Assert::equals($expected, $this->run('use lang\\Value, lang\\ast\\syntax\\php\\unittest\\Point; class %T {
       public function run() {
         return '.$expr.';
+      }
+    }'));
+  }
+
+  #[Test, Expect(class: NullPointerException::class, message: 'Undefined variable: z')]
+  public function delayed_binding() {
+    Assert::equals([false, null], $this->run('use lang\\ast\\syntax\\php\\unittest\\Point; class %T {
+      public function run() {
+        new Point(1, -1) is Point(x: 0, :$z);
+        return $z;
       }
     }'));
   }

--- a/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariableBindingTest.class.php
@@ -49,8 +49,8 @@ class VariableBindingTest extends EmittingTest {
   public function compound_binding($input) {
     Assert::equals('apple', $this->run('class %T {
       public function run($command) {
-        return match ($command) is {
-          ["get", $object]|["pick", "up", $object]|["pick", $object, "up"] => $object,
+        return match ($command) {
+          is ["get", $object]|["pick", "up", $object]|["pick", $object, "up"] => $object,
           default => null,
         };
       }
@@ -61,8 +61,8 @@ class VariableBindingTest extends EmittingTest {
   public function bind_with_subpattern($input, $expected) {
     Assert::equals($expected, $this->run('class %T {
       public function run($command) {
-        return match ($command) is {
-          ["go", $direction & ("north"|"south"|"east"|"west")] => $direction,
+        return match ($command) {
+          is ["go", $direction & ("north"|"south"|"east"|"west")] => $direction,
           default => null,
         };
       }

--- a/src/test/php/lang/ast/syntax/php/unittest/VariablePinningTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariablePinningTest.class.php
@@ -17,6 +17,7 @@ class VariablePinningTest extends EmittingTest {
     yield ['$y= 2; return [1, 2] is [1, ^$y]', true];
     yield ['$y= 2; return [1, 0] is [1, ^$y]', false];
 
+    yield ['return PHP_INT_MAX is ^PHP_INT_MAX', true];
     yield ['return [1, 0] is [1, ^self::ZERO]', true];
     yield ['return [1, 2] is [1, ^self::ZERO]', false];
   }

--- a/src/test/php/lang/ast/syntax/php/unittest/VariablePinningTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/VariablePinningTest.class.php
@@ -1,0 +1,34 @@
+<?php namespace lang\ast\syntax\php\unittest;
+
+use lang\ast\unittest\emit\EmittingTest;
+use test\{Assert, Test, Values};
+
+/** @see https://wiki.php.net/rfc/pattern-matching#variable_pinning */
+class VariablePinningTest extends EmittingTest {
+
+  /** @return iterable */
+  private function fixtures() {
+    yield ['$y= 2; return new Point(1, 2) is Point(x: 1, y: ^$y)', true];
+    yield ['$y= 2; return new Point(1, 0) is Point(x: 1, y: ^$y)', false];
+
+    yield ['return new Point(1, 0) is Point(x: 1, y: ^self::ZERO)', true];
+    yield ['return new Point(1, 2) is Point(x: 1, y: ^self::ZERO)', false];
+
+    yield ['$y= 2; return [1, 2] is [1, ^$y]', true];
+    yield ['$y= 2; return [1, 0] is [1, ^$y]', false];
+
+    yield ['return [1, 0] is [1, ^self::ZERO]', true];
+    yield ['return [1, 2] is [1, ^self::ZERO]', false];
+  }
+
+  #[Test, Values(from: 'fixtures')]
+  public function test($expr, $expected) {
+    Assert::equals($expected, $this->run('use lang\\Value, lang\\ast\\syntax\\php\\unittest\\Point; class %T {
+      const ZERO= 0;
+
+      public function run() {
+        '.$expr.';
+      }
+    }'));
+  }
+}


### PR DESCRIPTION
This PR extends the basic type matching capabilities and implements all of https://wiki.php.net/rfc/pattern-matching 

## Implementation status

* [x] Literal patterns
* [x] Class constant patterns
* [x] Numeric comparison patterns
* [x] Object patterns
* [x] Array sequence patterns
* [X] Associative array patterns 
* [x] Compound patterns with `&` and `|`
* [x] Match expression syntax - `match (...) { is ... => ... }`, see https://wiki.php.net/rfc/pattern-matching#match_is_placement

## Notes

* The PHP PR currently uses a different *match* syntax as the one described in the RFC, [see here](https://github.com/php/php-src/pull/20574/changes#diff-7cbfc4175f8b9dc682896937bfc8347a19cab03a18434afae9ad5bdf9652a3c0R10)
* The PHP PR currently includes the *range* syntax listed under [Future scope](https://wiki.php.net/rfc/pattern-matching#range_pattern) in the RFC

## See also

* https://github.com/php/php-src/pull/20574
* https://externals.io/message/129490
* https://wiki.php.net/rfc/adts
* https://github.com/Crell/php-rfcs/blob/master/pattern-matching/future.md